### PR TITLE
Fix comment typo in App.tsx

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -77,7 +77,7 @@ const App = () => {
     }
   };
 
-  // Check for existing identifers on load and set them to state
+  // Check for existing identifiers on load and set them to state
   useEffect(() => {
     const getIdentifiers = async () => {
       const _ids = await agent.didManagerFind();


### PR DESCRIPTION
## Summary
- fix a typo in the identifier comment

## Testing
- `npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off App.tsx` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe2958b4832fad1a035fe9c54843